### PR TITLE
fix uppercase M in checkJwt imports

### DIFF
--- a/routes/cleanerRoutes.js
+++ b/routes/cleanerRoutes.js
@@ -3,8 +3,8 @@ const express = require('express');
 const router = express.Router();
 
 // Middleware
-const checkJwt = require('../Middleware/checkJwt');
-const checkUserInfo = require('../Middleware/checkUserInfo');
+const checkJwt = require('../middleware/checkJwt');
+const checkUserInfo = require('../middleware/checkUserInfo');
 
 // Helpers
 const userModel = require('../models/userModel');

--- a/routes/guestRoutes.js
+++ b/routes/guestRoutes.js
@@ -3,8 +3,8 @@ const express = require('express');
 const router = express.Router();
 
 // Middleware
-const checkJwt = require('../Middleware/checkJwt');
-const checkUserInfo = require('../Middleware/checkUserInfo');
+const checkJwt = require('../middleware/checkJwt');
+const checkUserInfo = require('../middleware/checkUserInfo');
 
 // Helpers
 const guestModel = require('../models/guestModel');

--- a/routes/inviteRoutes.js
+++ b/routes/inviteRoutes.js
@@ -3,8 +3,8 @@ const express = require('express');
 const router = express.Router();
 
 // Middleware
-const checkJwt = require('../Middleware/checkJwt');
-const checkUserInfo = require('../Middleware/checkUserInfo');
+const checkJwt = require('../middleware/checkJwt');
+const checkUserInfo = require('../middleware/checkUserInfo');
 
 // Helpers
 const inviteModel = require('../models/inviteModel');

--- a/routes/propertyRoutes.js
+++ b/routes/propertyRoutes.js
@@ -3,8 +3,8 @@ const express = require('express');
 const router = express.Router();
 
 // Middleware
-const checkJwt = require('../Middleware/checkJwt');
-const checkUserInfo = require('../Middleware/checkUserInfo');
+const checkJwt = require('../middleware/checkJwt');
+const checkUserInfo = require('../middleware/checkUserInfo');
 
 // Helpers
 const userModel = require('../models/userModel');

--- a/routes/taskRoutes.js
+++ b/routes/taskRoutes.js
@@ -3,8 +3,8 @@ const express = require('express');
 const router = express.Router();
 
 // Middleware
-const checkJwt = require('../Middleware/checkJwt');
-const checkUserInfo = require('../Middleware/checkUserInfo');
+const checkJwt = require('../middleware/checkJwt');
+const checkUserInfo = require('../middleware/checkUserInfo');
 
 // Helpers
 const taskModel = require('../models/taskModel');


### PR DESCRIPTION
Fixes an issue with a directory having an uppercase M

`Middleware` vs `middleware`. Heroku doesn't like this.