### PR TITLE
Routes/partners

### DIFF
--- a/models/propertyModel.js
+++ b/models/propertyModel.js
@@ -16,6 +16,7 @@ module.exports = {
 
 	getCleaners,
 	changeCleaner,
+	getPartners,
 
 	checkCleaner,
 	updateAvailability
@@ -171,6 +172,14 @@ function getCleaners(manager_id) {
 	return db('partners')
 		.where({ manager_id })
 		.select('cleaner_id');
+}
+
+async function getPartners(manager_id){
+	 const partners = await db('users')
+	 	.join('partners', 'users.user_id', 'partners.cleaner_id')
+	 	.where({manager_id})
+	 	.select('*');
+	return partners;
 }
 
 async function changeCleaner(property_id, cleaner_id) {

--- a/routes/cleanerRoutes.js
+++ b/routes/cleanerRoutes.js
@@ -58,7 +58,7 @@ router.get('/', checkJwt, checkUserInfo, async (req, res) => {
 router.get('/partners', checkJwt, checkUserInfo, async (req, res) => {
 	try{
 		const manager_id = req.user.user_id;
-		const partners = await propertyModels.getPartners(manager_id);
+		const partners = await propertyModel.getPartners(manager_id);
 		return res.status(200).json({partners});
 	}
 	catch(error){

--- a/routes/cleanerRoutes.js
+++ b/routes/cleanerRoutes.js
@@ -54,6 +54,19 @@ router.get('/', checkJwt, checkUserInfo, async (req, res) => {
 	}
 });
 
+
+router.get('/partners', checkJwt, checkUserInfo, async (req, res) => {
+	try{
+		const manager_id = req.user.user_id;
+		const partners = await propertyModels.getPartners(manager_id);
+		return res.status(200).json({partners});
+	}
+	catch(error){
+		console.log(error);
+		return res.status(500).json({error});
+	}
+});
+
 /**
  * Update the default cleaner for a property
  */


### PR DESCRIPTION
Changelog:
-Implemented a different route and model for gathering the partners that belong to a manager user_id

There already is an existing getCleaners() method in our endpoints but I was unable to get it functioning after much trial and error. We can have a discussion on whether we should keep both or refactor one of them.