### PR TITLE
Account Settings Page (backend)

### DIFF
--- a/data/migrations/20190501115651_users.js
+++ b/data/migrations/20190501115651_users.js
@@ -12,13 +12,30 @@ exports.up = function(knex, Promise) {
 			.notNullable()
 			.unique();
 
-		table.string('role', 16).notNullable();
+		table
+			.string('role', 16)
+			.notNullable();
 
-		table.string('img_url', 256);
+		table
+			.string('img_url', 256);
 
-		table.string('phone', 32);
+		table
+			.string('phone', 32);
 
-		table.string('address', 256);
+		table
+			.string('address', 256);
+
+		table
+			.string('auth_provider', 128)
+			.notNullable();
+
+		table
+            .timestamp('createdAt')
+            .defaultTo(knex.fn.now());
+        
+        table
+            .timestamp('updatedAt')
+            .defaultTo(knex.fn.now());
 	});
 };
 

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -21,7 +21,7 @@ async function getUserById(user_id){
 	return user;
 }
 
-async function addUser(user_name, email, img_url, role) {
+async function addUser(user_name, email, img_url, role, auth_provider) {
 	// Is user_name or email already taken?
 	const [notUnique] = await db('users')
 		.where({ user_name })
@@ -40,7 +40,7 @@ async function addUser(user_name, email, img_url, role) {
 
 	// Add new user
 	const [user] = await db('users').insert(
-		{ user_name, email, img_url, role },
+		{ user_name, email, img_url, role, auth_provider },
 		'*'
 	);
 

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -4,7 +4,8 @@ module.exports = {
 	getUserByEmail,
 	addUser,
 	getUserById,
-	getPartner
+	getPartner,
+	updateUser,
 };
 
 function getUserByEmail(email) {
@@ -53,4 +54,8 @@ function getPartner(manager_id, cleaner_id) {
 	return db('partners')
 		.where({ manager_id, cleaner_id })
 		.first();
+}
+
+function updateUser(user_id, changes){
+	return db('users').returning('*').where({user_id}).update(changes);
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 		"mailgun-js": "^0.22.0",
 		"moment": "^2.24.0",
 		"morgan": "^1.9.1",
-		"pg": "^7.6.1"
+		"pg": "^7.6.1",
+		"request-promise": "^4.2.4"
 	},
 	"devDependencies": {
 		"jest": "^24.5.0",

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -4,6 +4,7 @@ const router = express.Router();
 
 // Middleware
 const checkJwt = require('../middleware/checkJwt');
+const checkUserInfo  = require('../middleware/checkUserInfo');
 
 // Helpers
 const userModel = require('../models/userModel');
@@ -49,11 +50,25 @@ router.post('/login/:inviteCode*?', checkJwt, async (req, res) => {
 		const userInfo = generateToken(user, exp);
 
 		// Return user info
-		res.status(200).json({ userInfo, inviteStatus });
+		res.status(200).json({ userInfo, inviteStatus, user });
 	} catch (error) {
 		console.error(error);
 		res.status(500).json({ error });
 	}
 });
+
+
+router.put('/update-user', checkJwt, checkUserInfo, async (req, res) => {
+	let user = req.user;
+
+	console.log('old user', user);
+
+	let newUser = {...user, ...req.body};
+
+	console.log('new user', newUser);
+
+	return res.status(200).json({newUser});
+
+})
 
 module.exports = router;

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -18,21 +18,24 @@ router.post('/login/:inviteCode*?', checkJwt, async (req, res) => {
 	const { inviteCode } = req.params;
 
 	// TODO: verify arguments are properly formatted and respond with errors for bad strings
-
+	
 	try {
 		// Find user else create a new one
+		const auth_provider = req.user.sub.split('|');
+		
 		const user =
 			(await userModel.getUserByEmail(email)) ||
 			(await userModel.addUser(
 				user_name,
 				email,
 				img_url,
-				inviteCode ? 'assistant' : role
+				inviteCode ? 'assistant' : role,
+				auth_provider[0]
 			));
 
 		if (user.notUnique) {
 			// user_name and/or email are already taken
-			res.status(409).json({ notUnique });
+			return res.status(409).json({ notUnique });
 		}
 
 		// Attempt to accept invite if provided with inviteCode
@@ -50,10 +53,11 @@ router.post('/login/:inviteCode*?', checkJwt, async (req, res) => {
 		const userInfo = generateToken(user, exp);
 
 		// Return user info
-		res.status(200).json({ userInfo, inviteStatus, user });
+		console.log(req.user);
+		return res.status(200).json({ userInfo, inviteStatus, user });
 	} catch (error) {
 		console.error(error);
-		res.status(500).json({ error });
+		return res.status(500).json({ error });
 	}
 });
 

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -18,10 +18,12 @@ router.post('/login/:inviteCode*?', checkJwt, async (req, res) => {
 	const { inviteCode } = req.params;
 
 	// TODO: verify arguments are properly formatted and respond with errors for bad strings
-	
+	console.log(req.user.sub);
+
 	try {
 		// Find user else create a new one
 		const auth_provider = req.user.sub.split('|');
+		console.log('PROVIDER', auth_provider);
 		
 		const user =
 			(await userModel.getUserByEmail(email)) ||
@@ -62,7 +64,7 @@ router.post('/login/:inviteCode*?', checkJwt, async (req, res) => {
 });
 
 
-router.put('/update-user', checkJwt, checkUserInfo, async (req, res) => {
+router.put('/', checkJwt, checkUserInfo, async (req, res) => {
 	let user = req.user;
 
 	console.log('old user', user);

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -71,8 +71,11 @@ router.put('/:user_id', checkJwt, checkUserInfo, async (req, res) => {
 	const changes = req.body;
 
 	// update auth0 with the new user information
+
+	// the auth0 api user id
 	const auth0id = req.user.sub;
 
+	// initialize the body object
 	const updateObj = {};
 
 	// parse which fields to send in the update
@@ -81,6 +84,8 @@ router.put('/:user_id', checkJwt, checkUserInfo, async (req, res) => {
 		updateObj.username = changes.user_name;
 	} else if (changes.password){
 		updateObj.password = changes.password;
+	} else if (changes.email){
+		updateObj.email = changes.email;
 	}
 
 	const auth0user = {
@@ -104,27 +109,15 @@ router.put('/:user_id', checkJwt, checkUserInfo, async (req, res) => {
 
 		userModel.updateUser(user_id, userUpdate).then(status => {
 			console.log('internal status', status);
+			return res.status(200).json({user: status});
+		}).catch(err => {
+			console.log(err);
+			return res.status(500).json({error: `Internal server error.`})
 		})
 	}).catch(err => {
 		console.log(err);
+		return res.status(500).json({error: `Internal server error.`})
 	})
-
-
-
-
-
-
-
-	// update our database with the returned information
-
-	// usersDb.update(user_id, changes).then(status => {
-	// 	console.log('put response', status);
-	// 	return res.status(200).json({message: `User updated successfully.`, user: response[0]});
-	// }).catch(err => {
-	// 	console.log(err);
-	// 	return res.status(500).json({error: `Internal server error.`})
-	// })
-	return res.status(200).json({message: 'Success'});
 })
 
 module.exports = router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,6 +732,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+bluebird@^3.5.0:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
+
 bluebird@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
@@ -4355,6 +4360,16 @@ request-promise-native@^1.0.5:
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
   integrity sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==
   dependencies:
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
+
+request-promise@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.4.tgz#1c5ed0d71441e38ad58c7ce4ea4ea5b06d54b310"
+  integrity sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==
+  dependencies:
+    bluebird "^3.5.0"
     request-promise-core "1.1.2"
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"


### PR DESCRIPTION
This gives us an account page to view and manage user profile information.

Any account registered via social login will have their account profile set as read-only, and any user that signs up via email and password can manage their username, email, and passwords all from our account management page.

Currently, the auth0 API management token is set within the backend .env file. This will eventually need to be generated programmatically, but for testing purposes this is sufficient for now.

User interactions are conditionally rendered based on which field they wish to edit, and I've tested to ensure that the re-rendering occurs properly once the update is executed.

**NOTE: This will require a re-migration, since we are adding a field to the users table to keep track of the user's `auth_provider`.**