### PR TITLE
Properties edit/deletion handling

### DIFF
--- a/data/migrations/20190501115804_guests.js
+++ b/data/migrations/20190501115804_guests.js
@@ -6,7 +6,8 @@ exports.up = function(knex, Promise) {
 			.integer('property_id')
 			.unsigned()
 			.notNullable()
-			.references('properties.property_id');
+			.references('properties.property_id')
+			.onDelete('CASCADE');
 
 		table
 			.integer('cleaner_id')

--- a/models/propertyModel.js
+++ b/models/propertyModel.js
@@ -20,7 +20,8 @@ module.exports = {
 	getPartners,
 
 	checkCleaner,
-	updateAvailability
+	updateAvailability,
+	deleteProperty,
 };
 
 async function getProperties(user_id, role) {
@@ -214,4 +215,8 @@ async function updateAvailability(cleaner_id, property_id, available) {
 		: await db('available_cleaners')
 				.where({ cleaner_id, property_id })
 				.del();
+}
+
+function deleteProperty(property_id){
+	return db('properties').where({property_id}).del();
 }

--- a/models/propertyModel.js
+++ b/models/propertyModel.js
@@ -26,7 +26,7 @@ module.exports = {
 
 async function getProperties(user_id, role) {
 	const managerPropertyFields =
-		'p.property_id, p.property_name, p.cleaner_id, p.address, p.img_url, p.guest_guide, p.assistant_guide';
+		'p.property_id, p.manager_id, p.property_name, p.cleaner_id, p.address, p.img_url, p.guest_guide, p.assistant_guide';
 
 	const assistantPropertyFields =
 		'p.property_id, p.property_name, p.manager_id, p.address, p.img_url, p.guest_guide, p.assistant_guide';

--- a/routes/propertyRoutes.js
+++ b/routes/propertyRoutes.js
@@ -111,18 +111,20 @@ router.put('/:property_id', checkJwt, checkUserInfo, async (req, res) => {
 		assistant_guide
 	} = req.body;
 
-	const propertyInfo = {
-		property_name,
-		address,
-		img_url,
-		cleaner_id,
-		guest_guide,
-		assistant_guide
-	};
+	// Programmatically assign updated values based on what has been submitted
+	const propertyInfo = {};
+
+	for(var key in req.body){
+		if(key !== undefined){
+			propertyInfo[key] = req.body[key]
+		}
+	}
 
 	if (role !== 'manager') {
 		return res.status(403).json({ error: 'not a manager' });
 	}
+
+	console.log('UPDATE PROPERTY', propertyInfo);
 
 	try {
 		if (cleaner_id && !(await userModel.getPartner(user_id, cleaner_id))) {

--- a/routes/propertyRoutes.js
+++ b/routes/propertyRoutes.js
@@ -159,8 +159,6 @@ router.delete('/:property_id', checkJwt, checkUserInfo, (req, res) => {
 	const property_id = req.params.property_id;
 
 	propertyModel.deleteProperty(property_id).then(status => {
-		console.log(status);
-
 		return res.status(200).json({message: `Property successfully deleted.`})
 	}).catch(err => {
 		console.log(err);

--- a/routes/propertyRoutes.js
+++ b/routes/propertyRoutes.js
@@ -124,8 +124,6 @@ router.put('/:property_id', checkJwt, checkUserInfo, async (req, res) => {
 		return res.status(403).json({ error: 'not a manager' });
 	}
 
-	console.log('UPDATE PROPERTY', propertyInfo);
-
 	try {
 		if (cleaner_id && !(await userModel.getPartner(user_id, cleaner_id))) {
 			return res.status(404).json({ error: 'invalid assistant' });

--- a/routes/propertyRoutes.js
+++ b/routes/propertyRoutes.js
@@ -155,7 +155,18 @@ router.put('/:property_id', checkJwt, checkUserInfo, async (req, res) => {
  * Delete a property
  */
 
+router.delete('/:property_id', checkJwt, checkUserInfo, (req, res) => {
+	const property_id = req.params.property_id;
 
+	propertyModel.deleteProperty(property_id).then(status => {
+		console.log(status);
+
+		return res.status(200).json({message: `Property successfully deleted.`})
+	}).catch(err => {
+		console.log(err);
+		return res.status(500).json({error: `Internal server error.`})
+	})
+})
 
 /** Update availability */
 router.put(

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -147,6 +147,8 @@ router.put('/:user_id', checkJwt, checkUserInfo, async (req, res) => {
 
 	rp.patch(auth0user)
 		.then(status => {
+
+			console.log("UPDATE USER");
 			// parse the returned updated auth0 user object for our internal api
 			const userUpdate = {
 				user_name: status.username,


### PR DESCRIPTION
Enables property edits and deletions. 

Solves an issue with property deletion, the property_id foreign key in guests migration should have a cascade designation on delete. **This will require a remigration.**

Additionally, ensured that the manager_id is passed back with property queries for easier handling on the front-end. Not sure how that was missing. (propertiesModel)

I also made it so that the property update values are based on what is present in the request itself, rather than using fixed designators. This should simplify front-end req.body submissions, though they'll need to be consistent with the table column names. They would have to be consistent regardless, but this change means we don't have to completely populate the property object with each front-end submission, and only need to send the relevant fields that are being updated.