### PR TITLE
Availability routes compartmentalization

### DIFF
--- a/models/partnerModel.js
+++ b/models/partnerModel.js
@@ -1,0 +1,9 @@
+const db = require('../data/dbConfig');
+
+module.exports = {
+	getManagerIds,
+};
+
+function getManagerIds(cleaner_id){
+    return db.select('manager_id').from('partners').where({cleaner_id});
+}

--- a/models/propertyModel.js
+++ b/models/propertyModel.js
@@ -24,7 +24,43 @@ module.exports = {
 	checkCleaner,
 	updateAvailability,
 	deleteProperty,
+
+	getManagerProperties,
+	getAvailableCleaners,
+	getAvailableProperties,
+
+	addAvailability,
+	removeAvailability,
 };
+
+function getManagerProperties(manager_id){
+	return db.select('*').from('properties').where({manager_id});
+}
+
+function getAvailableProperties(cleaner_id){
+	console.log("CLEANER ID", cleaner_id);
+	return db.select('property_id').from('available_cleaners').where({cleaner_id});
+}
+
+function getAvailableCleaners(property_id){
+	return db.select('cleaner_id').from('available_cleaners').where({property_id});
+}
+
+/**
+ * 
+ * entry = {
+ * cleaner_id: 1,
+ * property_id: 2
+ * }
+ */
+
+function addAvailability(entry){
+	return db('available_cleaners').insert(entry).into('available_cleaners');
+}
+
+function removeAvailability(entry){
+	return db('available_cleaners').returning(1).where(entry).del();
+}
 
 async function getProperties(user_id, role) {
 	const managerPropertyFields =

--- a/routes/availabilityRoutes.js
+++ b/routes/availabilityRoutes.js
@@ -1,0 +1,87 @@
+// Dependencies
+const express = require('express');
+const router = express.Router();
+
+// Middleware
+const checkJwt = require('../middleware/checkJwt');
+const checkUserInfo = require('../middleware/checkUserInfo');
+
+// Helpers
+const userModel = require('../models/userModel');
+const propertyModel = require('../models/propertyModel');
+const partnerModel = require('../models/partnerModel');
+
+
+// Mailgun 
+const mailgunKey = process.env.MAILGUN_KEY;
+const mailgunDomain = process.env.MAILGUN_URL;
+const Mailgun = require('mailgun-js');
+
+
+/**
+ * Get property availability
+ * Checks for properties marked as available
+ * This will be matched against the partner's properties to see if availability
+ * has been added or not
+ */
+
+ router.get('/', (req, res) => {
+     return res.status(200).json({m: 'success'})
+ })
+
+router.get('/available_properties', checkJwt, checkUserInfo, (req, res) => {
+	const cleaner_id = req.user.user_id;
+
+	propertyModel.getAvailableProperties(cleaner_id).then(properties => {
+		return res.status(200).json({available_properties: properties})
+	}).catch(err => {
+		console.log(err);
+		return res.status(500).json({error: `Internal server error.`})
+	})
+})
+
+router.get('/available_cleaners/:property_id', checkJwt, checkUserInfo, (req, res) => {
+	const property_id = req.params.property_id;
+
+	propertyModel.getAvailableCleaners(property_id).then(cleaners => {
+		console.log('AVAIL CLEANERS', cleaners);
+
+		return res.status(200).json({available_partners: cleaners})
+	}).catch(err => {
+		console.log(err);
+		return res.status(500).json({error: `Internal server error.`})
+	})
+})
+
+/** Marks a property as available by adding an entry in the available_cleaners table */
+
+router.post('/available_properties', checkJwt, checkUserInfo, (req, res) => {
+	
+	const entry = {
+		cleaner_id: req.user.user_id,
+		property_id: req.body.property_id,
+	}
+
+	propertyModel.addAvailability(entry).then(status => {
+		return res.status(200).json({message: `Availability added.`})
+	}).catch(err => {
+		console.log(err);
+		return res.status(500).json({error: `Internal server error.`})
+	})
+})
+
+router.delete('/available_properties/:property_id', checkJwt, checkUserInfo, (req, res) => {
+	const entry = {
+		cleaner_id: req.user.user_id,
+		property_id: req.params.property_id,
+	}
+
+	propertyModel.removeAvailability(entry).then(status => {
+		return res.status(200).json({message: `Availability removed.`})
+	}).catch(err => {
+		console.log(err);
+		return res.status(500).json({error: `Internal server error.`})
+	})
+})
+
+module.exports = router;

--- a/routes/propertyRoutes.js
+++ b/routes/propertyRoutes.js
@@ -9,6 +9,7 @@ const checkUserInfo = require('../middleware/checkUserInfo');
 // Helpers
 const userModel = require('../models/userModel');
 const propertyModel = require('../models/propertyModel');
+const partnerModel = require('../models/partnerModel');
 
 // Mailgun 
 const mailgunKey = process.env.MAILGUN_KEY;
@@ -19,14 +20,35 @@ const Mailgun = require('mailgun-js');
 /** Get properties by user_id */
 router.get('/', checkJwt, checkUserInfo, async (req, res) => {
 	const { user_id, role } = req.user;
-	try {
-		const properties = await propertyModel.getProperties(user_id, role);
+	if(role === 'manager'){
+		// if manager, collect properties for that manager
+		propertyModel.getProperties(user_id, role).then(properties => {
+			return res.status(200).json({properties});
+		})
+	} else {
+		// if assistant, collect all properties from all managers
+		partnerModel.getManagerIds(user_id).then(manager_ids => {
+			let manager_properties = [];
+			for(let i = 0; i < manager_ids.length; i++){
+				propertyModel.getProperties(manager_ids[i].manager_id, 'manager').then(property => {
+					manager_properties.push(property[0]);
+					// when we reach end of manager_ids, return collected properties
+					if(i === manager_ids.length - 1){
+						return res.status(200).json({properties: manager_properties});
+					}
+				})
+			}
+		})
 
-		return res.status(200).json({ properties });
-	} catch (error) {
-		console.error(error);
-		return res.status(500).json({ error });
 	}
+	// try {
+	// 	const properties = await propertyModel.getProperties(user_id, role);
+
+	// 	return res.status(200).json({ properties });
+	// } catch (error) {
+	// 	console.error(error);
+	// 	return res.status(500).json({ error });
+	// }
 });
 
 /** Get properties with less info for 'default properties' dropdowns */
@@ -251,6 +273,7 @@ router.delete('/:property_id', checkJwt, checkUserInfo, (req, res) => {
 		return res.status(500).json({error: `Internal server error.`})
 	})
 })
+
 
 /** Update availability */
 router.put(

--- a/routes/propertyRoutes.js
+++ b/routes/propertyRoutes.js
@@ -30,8 +30,16 @@ router.get('/', checkJwt, checkUserInfo, async (req, res) => {
 		partnerModel.getManagerIds(user_id).then(manager_ids => {
 			let manager_properties = [];
 			for(let i = 0; i < manager_ids.length; i++){
-				propertyModel.getProperties(manager_ids[i].manager_id, 'manager').then(property => {
-					manager_properties.push(property[0]);
+				propertyModel.getProperties(manager_ids[i].manager_id, 'manager').then(properties => {
+					
+					// for the first manager, use the returned array
+					if(i === 0){
+						manager_properties = properties;
+					} else {
+						// for subsqeuent managers, push into existing array
+						manager_properties[0].push(properties)
+					}
+					
 					// when we reach end of manager_ids, return collected properties
 					if(i === manager_ids.length - 1){
 						return res.status(200).json({properties: manager_properties});

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -42,7 +42,7 @@ router.post('/login/:inviteCode*?', checkJwt, async (req, res) => {
 
 		if (user.notUnique) {
 			// user_name and/or email are already taken
-			return res.status(409).json({ notUnique });
+			return res.status(409).json({error: `That username/email is already taken.`});
 		}
 
 		// Attempt to accept invite if provided with inviteCode

--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ const taskRoutes = require('./routes/taskRoutes');
 const guestRoutes = require('./routes/guestRoutes');
 const reportRoutes = require('./routes/reportRoutes');
 const cleanerRoutes = require('./routes/cleanerRoutes');
+const availabilityRoutes = require('./routes/availabilityRoutes');
 
 // Endpoints
 server.use('/api/users', userRoutes);
@@ -38,6 +39,7 @@ server.use('/api/tasks', taskRoutes);
 server.use('/api/guests', guestRoutes);
 server.use('/api/reports', reportRoutes);
 server.use('/api/cleaners', cleanerRoutes);
+server.use('/api/avail', availabilityRoutes);
 
 // Error handler
 server.use(errorHandler);


### PR DESCRIPTION
Compartmentalizes availability entry, deletion, and retrieval methods into their own router.

Adds routes for availability handling for both cleaners and managers (only cleaner additions/deletions are currently implemented on the front-end). Cleaners need to know available properties, managers need to know available cleaners. Simple as.

Revises the route to fetch all properties. Ensures that a partner with multiple managers can see all properties from all managers. 

The availability routes are reachable via `/api/avail`, since typing `availabilities` every time is a nuisance tbh.